### PR TITLE
[ IMPORTANT ] Fixing the Context Load for hang in custom openGL context.

### DIFF
--- a/glfw.v
+++ b/glfw.v
@@ -252,9 +252,8 @@ pub fn is_extension_supported(extension string) !bool {
 }
 
 // get_proc_address returns the process address
-pub fn get_proc_address(proc_name string) !FnGLProc {
-	adr := C.glfwGetProcAddress(proc_name.str)
-	check_error()!
+pub fn get_proc_address(c &char) FnGLProc {
+	mut adr := C.glfwGetProcAddress(c)
 	return adr
 }
 

--- a/types.v
+++ b/types.v
@@ -31,7 +31,7 @@ pub mut:
 }
 
 // Function pointers
-type FnGLProc = fn ()
+type FnGLProc = fn (&char)
 
 type FnVkProc = fn ()
 


### PR DESCRIPTION
This update is necessary to bind an custom OpenGL context into GLFW. Since Im working on openGL Bindings with ignoring the glfw-included gl.h with GLAD-Loader, this is important, to change this function. 